### PR TITLE
feat: camera detection toggle in header

### DIFF
--- a/main.py
+++ b/main.py
@@ -604,6 +604,34 @@ class Api(QObject):
         return self._dashboard_service.export_to_excel()
 
     @pyqtSlot(result="QVariant")
+    def get_camera_status(self) -> dict:
+        """Return camera detection feature status."""
+        if not self._proximity_manager:
+            return {"enabled": False, "running": False}
+        return {
+            "enabled": True,
+            "running": bool(self._proximity_manager._running),
+        }
+
+    @pyqtSlot(result="QVariant")
+    def toggle_camera(self) -> dict:
+        """Toggle camera detection on/off at runtime."""
+        if not self._proximity_manager:
+            return {"ok": False, "running": False, "message": "Camera not configured"}
+        if self._proximity_manager._running:
+            self._proximity_manager.stop()
+            LOGGER.info("[Camera] Toggled OFF by user")
+            return {"ok": True, "running": False, "message": "Camera stopped"}
+        started = self._proximity_manager.start()
+        if started:
+            LOGGER.info("[Camera] Toggled ON by user")
+        return {
+            "ok": started,
+            "running": started,
+            "message": "Camera started" if started else "Camera failed to start",
+        }
+
+    @pyqtSlot(result="QVariant")
     def is_admin_enabled(self) -> dict:
         """Check if admin features are available."""
         return {"enabled": config.ADMIN_FEATURES_ENABLED}

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -110,6 +110,49 @@ body > header h1 {
     }
 }
 
+/* Camera Toggle - positioned left of dashboard icon */
+.camera-toggle {
+    position: fixed;
+    top: 20px;
+    right: 190px;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    z-index: 1000;
+    transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.camera-toggle--hidden {
+    display: none;
+}
+
+.camera-toggle--on {
+    color: var(--deloitte-green);
+}
+
+.camera-toggle--on .camera-toggle__on { display: block; }
+.camera-toggle--on .camera-toggle__off { display: none; }
+
+.camera-toggle--off {
+    color: rgba(255, 255, 255, 0.35);
+}
+
+.camera-toggle--off .camera-toggle__on { display: none; }
+.camera-toggle--off .camera-toggle__off { display: block; }
+
+.camera-toggle:hover {
+    color: var(--deloitte-green);
+    transform: scale(1.1);
+}
+
+.camera-toggle svg {
+    width: 20px;
+    height: 20px;
+}
+
 /* Dashboard Icon (Issue #27) - positioned next to connection status */
 .dashboard-icon {
     position: fixed;

--- a/web/index.html
+++ b/web/index.html
@@ -22,6 +22,14 @@
             <h1>Station : <span id="station-name">--</span></h1>
         </div>
         <span class="connection-status connection-status--unknown" id="connection-status" aria-label="API connection status" title="Checking connection"></span>
+        <span class="camera-toggle camera-toggle--hidden" id="camera-toggle" title="Camera Detection">
+            <svg class="camera-toggle__on" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
+                <path d="M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4z"/>
+            </svg>
+            <svg class="camera-toggle__off" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
+                <path d="M21 6.5l-4 4V7c0-.55-.45-1-1-1H9.82L21 17.18V6.5zM3.27 2L2 3.27 4.73 6H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.21 0 .39-.08.54-.18L19.73 21 21 19.73 3.27 2z"/>
+            </svg>
+        </span>
         <span class="dashboard-icon" id="dashboard-icon" title="View Dashboard">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
                 <path d="M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z"/>


### PR DESCRIPTION
## Summary
- Adds a camera icon toggle button in the header bar (left of dashboard icon)
- Click to start/stop camera proximity detection at runtime — no restart needed
- Green videocam icon when active, dim videocam_off when stopped, hidden if not configured

## Changes
- `web/index.html` — camera toggle SVG icons in header
- `web/css/style.css` — toggle states (on/off/hidden) styling
- `web/script.js` — click handler, bridge calls, initial state loader
- `main.py` — `toggle_camera()` and `get_camera_status()` API slots

## Test plan
- [ ] Run with `ENABLE_CAMERA_DETECTION=True` → green camera icon visible
- [ ] Click icon → camera stops, icon dims, overlay disappears
- [ ] Click again → camera restarts, icon green, overlay returns
- [ ] Run with `ENABLE_CAMERA_DETECTION=False` → no camera icon
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)