### PR TITLE
feat: slider default markers, station rename sync, audio cleanup

### DIFF
--- a/audio.py
+++ b/audio.py
@@ -5,7 +5,7 @@ import random
 from pathlib import Path
 from typing import Optional
 
-from PyQt6.QtCore import QTimer, QUrl
+from PyQt6.QtCore import QUrl
 from PyQt6.QtMultimedia import QMediaPlayer, QAudioOutput
 
 LOGGER = logging.getLogger(__name__)
@@ -28,8 +28,6 @@ class VoicePlayer:
         self._player.errorOccurred.connect(self._on_error)
 
         self._load_voice_files()
-        # Defer pre-warm to avoid blocking startup (~300ms saved)
-        QTimer.singleShot(500, self._prewarm)
 
         LOGGER.info(
             "VoicePlayer initialized: enabled=%s, volume=%.2f, files=%d",
@@ -43,19 +41,6 @@ class VoicePlayer:
         self.voice_files = sorted(self.voices_dir.glob("*.mp3"))
         if not self.voice_files:
             LOGGER.warning("No MP3 files found in: %s", self.voices_dir)
-
-    def _prewarm(self) -> None:
-        """Pre-warm the audio pipeline so the first real play has no cold-start delay."""
-        if not self.voice_files:
-            return
-        # Temporarily mute, load first file, start+stop to init codec and audio device
-        self._audio_output.setVolume(0.0)
-        self._player.setSource(QUrl.fromLocalFile(str(self.voice_files[0].resolve())))
-        self._player.play()
-        self._player.stop()
-        # Restore volume
-        self._audio_output.setVolume(self._volume)
-        LOGGER.debug("Audio pipeline pre-warmed")
 
     def _pick_random(self) -> Path:
         """Pick a random voice file, avoiding consecutive repeats when possible."""

--- a/database.py
+++ b/database.py
@@ -120,6 +120,15 @@ class DatabaseManager:
                 (name.strip(),),
             )
 
+    def rename_station_scans(self, old_name: str, new_name: str) -> int:
+        """Update station_name on all historical scans from old_name to new_name."""
+        with self._connection:
+            cursor = self._connection.execute(
+                "UPDATE scans SET station_name = ? WHERE station_name = ? COLLATE NOCASE",
+                (new_name.strip(), old_name),
+            )
+            return cursor.rowcount
+
     def employees_loaded(self) -> bool:
         cursor = self._connection.execute("SELECT COUNT(1) FROM employees")
         return cursor.fetchone()[0] > 0

--- a/main.py
+++ b/main.py
@@ -401,6 +401,15 @@ class Api(QObject):
             "ok": False,
             "message": "Connection not checked yet",
         }
+        # Snapshot config defaults before saved settings override them
+        self._config_defaults = {
+            "voice_volume": config.VOICE_VOLUME,
+            "greeting_cooldown": config.CAMERA_GREETING_COOLDOWN_SECONDS,
+            "min_size_pct": config.CAMERA_MIN_SIZE_PCT,
+            "absence_threshold": config.CAMERA_ABSENCE_THRESHOLD_SECONDS,
+            "scan_feedback_ms": config.SCAN_FEEDBACK_DURATION_MS,
+            "connection_check_s": config.CONNECTION_CHECK_INTERVAL_MS / 1000,
+        }
         # Emit initial state so the UI can bind immediately
         QTimer.singleShot(0, lambda: self.connection_status_changed.emit(self._last_connection_result))
 
@@ -835,6 +844,7 @@ class Api(QObject):
             "scan_feedback_ms": config.SCAN_FEEDBACK_DURATION_MS,
             "connection_check_s": config.CONNECTION_CHECK_INTERVAL_MS / 1000,
             "dashboard_url": dashboard_url,
+            "defaults": self._config_defaults,
         }
 
     # ------------------------------------------------------------------
@@ -1144,7 +1154,27 @@ class Api(QObject):
             return {"ok": False, "message": "Station name cannot be empty"}
         old_name = self._service._db.get_station_name() or "Unknown"
         self._service._db.set_station_name(new_name)
-        LOGGER.info("[Admin] Station renamed: '%s' → '%s'", old_name, new_name)
+        updated = self._service._db.rename_station_scans(old_name, new_name)
+        LOGGER.info("[Admin] Station renamed: '%s' → '%s' (%d local scans updated)", old_name, new_name, updated)
+        # Sync rename to cloud in background
+        import threading
+        def _cloud_rename():
+            try:
+                import requests
+                resp = requests.put(
+                    f"{config.CLOUD_API_URL}/v1/stations/rename",
+                    json={"old_name": old_name, "new_name": new_name},
+                    headers={"x-api-key": config.CLOUD_API_KEY},
+                    timeout=10,
+                )
+                data = resp.json()
+                if data.get("ok"):
+                    LOGGER.info("[Admin] Cloud station rename: %d scans updated", data.get("scans_updated", 0))
+                else:
+                    LOGGER.warning("[Admin] Cloud station rename failed: %s", data.get("error", "unknown"))
+            except Exception as e:
+                LOGGER.warning("[Admin] Cloud station rename error: %s", e)
+        threading.Thread(target=_cloud_rename, daemon=True).start()
         return {"ok": True, "message": f"Station renamed to '{new_name}'", "old_name": old_name, "new_name": new_name}
 
     @pyqtSlot(result="QVariant")

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -1608,26 +1608,43 @@ body.dashboard-open {
 .adm-slider::-webkit-slider-runnable-track {
     -webkit-appearance: none !important; appearance: none !important;
     height: 8px; border-radius: 4px;
-    background: linear-gradient(to right, #86bc25 var(--fill, 80%), #ddd var(--fill, 80%)) !important;
+    background: linear-gradient(to right, var(--fill-color, #86bc25) var(--fill, 80%), #ddd var(--fill, 80%)) !important;
     border: none !important; box-shadow: none !important;
 }
 .adm-slider::-webkit-slider-thumb {
     -webkit-appearance: none !important; appearance: none !important;
-    width: 18px; height: 18px; border-radius: 50%;
-    background: #86bc25 !important; cursor: pointer;
+    width: 16px; height: 16px; border-radius: 50%;
+    background: var(--thumb-color, #86bc25) !important; cursor: pointer;
     border: 2px solid #fff !important;
     box-shadow: 0 1px 3px rgba(0,0,0,0.3) !important;
-    margin-top: -5px;
+    margin-top: -4px;
 }
 .adm-slider::-moz-range-track {
     height: 8px; border-radius: 4px;
-    background: linear-gradient(to right, #86bc25 var(--fill, 80%), #ddd var(--fill, 80%));
+    background: linear-gradient(to right, var(--fill-color, #86bc25) var(--fill, 80%), #ddd var(--fill, 80%));
     border: none;
 }
 .adm-slider::-moz-range-thumb {
-    width: 18px; height: 18px; border-radius: 50%;
-    background: #86bc25; cursor: pointer;
+    width: 16px; height: 16px; border-radius: 50%;
+    background: var(--thumb-color, #86bc25); cursor: pointer;
     border: 2px solid #fff; box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+}
+.adm-slider-wrap {
+    flex: 1; position: relative; display: flex; align-items: center;
+}
+.adm-slider-wrap .adm-slider { flex: 1; }
+.adm-slider-default-mark {
+    position: absolute;
+    /* Account for 16px thumb: track starts at 8px, ends at calc(100% - 8px) */
+    left: calc(8px + (100% - 16px) * var(--default-pct, 0.5));
+    top: 50%;
+    width: 14px; height: 14px;
+    background: rgba(0,0,0,0.12);
+    border: 2px solid rgba(255,255,255,0.85);
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    z-index: 0;
 }
 .adm-slider-row__value {
     font-size: 0.9rem; font-weight: 600; color: #333;

--- a/web/index.html
+++ b/web/index.html
@@ -326,7 +326,10 @@
                     </div>
                     <div class="adm-slider-row" style="margin-top:10px;">
                         <span class="adm-slider-row__label">Volume</span>
-                        <input type="range" class="adm-slider" id="admin-volume-slider" min="0" max="100" value="80" style="--fill:80%;">
+                        <div class="adm-slider-wrap" data-default="100" data-min="0" data-max="100" data-key="voice_volume" data-scale="100">
+                            <input type="range" class="adm-slider" id="admin-volume-slider" min="0" max="100" value="80" style="--fill:80%;">
+                            <div class="adm-slider-default-mark" style="--default-pct:1.0;" title="Default: 100%"></div>
+                        </div>
                         <span class="adm-slider-row__value" id="admin-volume-value">80%</span>
                     </div>
                 </div>
@@ -342,17 +345,26 @@
                     </div>
                     <div class="adm-slider-row" style="margin-top:10px;">
                         <span class="adm-slider-row__label">Cooldown</span>
-                        <input type="range" class="adm-slider" id="admin-cooldown-slider" min="5" max="300" value="60" step="5" style="--fill:18%;">
+                        <div class="adm-slider-wrap" data-default="60" data-min="5" data-max="120" data-key="greeting_cooldown">
+                            <input type="range" class="adm-slider" id="admin-cooldown-slider" min="5" max="120" value="60" step="5" style="--fill:47.8%;">
+                            <div class="adm-slider-default-mark" style="--default-pct:0.478;" title="Default: 60s"></div>
+                        </div>
                         <span class="adm-slider-row__value" id="admin-cooldown-value">60 sec</span>
                     </div>
                     <div class="adm-slider-row" style="margin-top:8px;">
                         <span class="adm-slider-row__label">Min Face</span>
-                        <input type="range" class="adm-slider" id="admin-minsize-slider" min="5" max="80" value="20" step="1" style="--fill:20%;">
+                        <div class="adm-slider-wrap" data-default="20" data-min="5" data-max="40" data-key="min_size_pct" data-scale="100">
+                            <input type="range" class="adm-slider" id="admin-minsize-slider" min="5" max="40" value="20" step="1" style="--fill:42.9%;">
+                            <div class="adm-slider-default-mark" style="--default-pct:0.429;" title="Default: 20%"></div>
+                        </div>
                         <span class="adm-slider-row__value" id="admin-minsize-value">20%</span>
                     </div>
                     <div class="adm-slider-row" style="margin-top:8px;">
                         <span class="adm-slider-row__label">Absence</span>
-                        <input type="range" class="adm-slider" id="admin-absence-slider" min="1" max="30" value="3" step="1" style="--fill:7%;">
+                        <div class="adm-slider-wrap" data-default="3" data-min="1" data-max="10" data-key="absence_threshold">
+                            <input type="range" class="adm-slider" id="admin-absence-slider" min="1" max="10" value="3" step="1" style="--fill:22.2%;">
+                            <div class="adm-slider-default-mark" style="--default-pct:0.222;" title="Default: 3s"></div>
+                        </div>
                         <span class="adm-slider-row__value" id="admin-absence-value">3 sec</span>
                     </div>
                 </div>
@@ -360,12 +372,18 @@
                     <div class="adm-section__header adm-section__header--display"><i class="material-icons">tv</i> Display</div>
                     <div class="adm-slider-row">
                         <span class="adm-slider-row__label">Feedback</span>
-                        <input type="range" class="adm-slider" id="admin-feedback-slider" min="1" max="10" value="2" step="1" style="--fill:11%;">
+                        <div class="adm-slider-wrap" data-default="2" data-min="1" data-max="10" data-key="scan_feedback_ms" data-scale="0.001">
+                            <input type="range" class="adm-slider" id="admin-feedback-slider" min="1" max="10" value="2" step="1" style="--fill:11.1%;">
+                            <div class="adm-slider-default-mark" style="--default-pct:0.111;" title="Default: 2s"></div>
+                        </div>
                         <span class="adm-slider-row__value" id="admin-feedback-value">2 sec</span>
                     </div>
                     <div class="adm-slider-row" style="margin-top:8px;">
                         <span class="adm-slider-row__label">Health Chk</span>
-                        <input type="range" class="adm-slider" id="admin-conncheck-slider" min="0" max="600" value="120" step="10" style="--fill:20%;">
+                        <div class="adm-slider-wrap" data-default="10" data-min="0" data-max="300" data-key="connection_check_s">
+                            <input type="range" class="adm-slider" id="admin-conncheck-slider" min="0" max="300" value="120" step="10" style="--fill:40%;">
+                            <div class="adm-slider-default-mark" style="--default-pct:0.033;" title="Default: 10s"></div>
+                        </div>
                         <span class="adm-slider-row__value" id="admin-conncheck-value">120 sec</span>
                     </div>
                 </div>

--- a/web/script.js
+++ b/web/script.js
@@ -1813,12 +1813,28 @@ ${destination}` : message;
     const adminConncheckValue = document.getElementById('admin-conncheck-value');
     const adminDashboardUrl = document.getElementById('admin-dashboard-url');
 
+    // Helper: check if slider is at default and update thumb color
+    const updateSliderDefaultState = (slider) => {
+        if (!slider) return;
+        const wrap = slider.closest('.adm-slider-wrap');
+        if (!wrap) return;
+        const defaultVal = parseFloat(wrap.dataset.default);
+        const currentVal = parseFloat(slider.value);
+        const isDefault = currentVal === defaultVal;
+        // Green when at default, orange when altered
+        slider.style.setProperty('--thumb-color', isDefault ? '#86bc25' : '#f0960a');
+        // Also update track fill color
+        const fillColor = isDefault ? '#86bc25' : '#f0960a';
+        slider.style.setProperty('--fill-color', fillColor);
+    };
+
     // Helper: update slider fill and value label
     const syncSlider = (slider, valueEl, val, min, max, unit) => {
         if (slider) {
             slider.value = val;
             const pct = max > min ? ((val - min) / (max - min)) * 100 : 0;
             slider.style.setProperty('--fill', pct + '%');
+            updateSliderDefaultState(slider);
         }
         if (valueEl) valueEl.textContent = val + ' ' + unit;
     };
@@ -1833,6 +1849,7 @@ ${destination}` : message;
             const pct = max > min ? ((v - min) / (max - min)) * 100 : 0;
             slider.style.setProperty('--fill', pct + '%');
             if (valueEl) valueEl.textContent = v + ' ' + unit;
+            updateSliderDefaultState(slider);
             saveFn(v);
         });
     };
@@ -1881,6 +1898,7 @@ ${destination}` : message;
                     if (adminVolumeSlider) {
                         adminVolumeSlider.value = volume;
                         adminVolumeSlider.style.setProperty('--fill', volume + '%');
+                        updateSliderDefaultState(adminVolumeSlider);
                     }
                     if (adminVolumeValue) {
                         adminVolumeValue.textContent = volume + '%';
@@ -1898,20 +1916,41 @@ ${destination}` : message;
                             adminCameraOverlayToggle.disabled = !result.camera_running;
                         }
                         const cooldown = result.greeting_cooldown || 60;
-                        syncSlider(adminCooldownSlider, adminCooldownValue, cooldown, 5, 300, 'sec');
+                        syncSlider(adminCooldownSlider, adminCooldownValue, cooldown, 5, 120, 'sec');
                         const minPct = Math.round((result.min_size_pct || 0.20) * 100);
-                        syncSlider(adminMinsizeSlider, adminMinsizeValue, minPct, 5, 80, '%');
+                        syncSlider(adminMinsizeSlider, adminMinsizeValue, minPct, 5, 40, '%');
                         const absence = result.absence_threshold || 3;
-                        syncSlider(adminAbsenceSlider, adminAbsenceValue, absence, 1, 30, 'sec');
+                        syncSlider(adminAbsenceSlider, adminAbsenceValue, absence, 1, 10, 'sec');
                     }
                     // Display section
-                    const feedbackSec = Math.round((result.scan_feedback_ms || 2000) / 1000);
+                    const feedbackSec = Math.round((result.scan_feedback_ms || 5000) / 1000);
                     syncSlider(adminFeedbackSlider, adminFeedbackValue, feedbackSec, 1, 10, 'sec');
                     const connCheck = result.connection_check_s ?? 120;
-                    syncSlider(adminConncheckSlider, adminConncheckValue, connCheck, 0, 600, 'sec');
+                    syncSlider(adminConncheckSlider, adminConncheckValue, connCheck, 0, 300, 'sec');
                     // Dashboard URL
                     if (adminDashboardUrl) {
                         adminDashboardUrl.textContent = result.dashboard_url || 'Not configured';
+                    }
+                    // Update default markers from config defaults
+                    const defs = result.defaults;
+                    if (defs) {
+                        document.querySelectorAll('.adm-slider-wrap[data-key]').forEach(wrap => {
+                            const key = wrap.dataset.key;
+                            if (!(key in defs)) return;
+                            let defVal = defs[key];
+                            const scale = parseFloat(wrap.dataset.scale || '1');
+                            defVal = Math.round(defVal * scale);
+                            const min = parseFloat(wrap.querySelector('.adm-slider').min);
+                            const max = parseFloat(wrap.querySelector('.adm-slider').max);
+                            wrap.dataset.default = defVal;
+                            const pct = max > min ? (defVal - min) / (max - min) : 0;
+                            const mark = wrap.querySelector('.adm-slider-default-mark');
+                            if (mark) {
+                                mark.style.setProperty('--default-pct', pct);
+                                mark.title = `Default: ${defVal}`;
+                            }
+                            updateSliderDefaultState(wrap.querySelector('.adm-slider'));
+                        });
                     }
                 });
             }
@@ -2013,6 +2052,7 @@ ${destination}` : message;
             const pct = parseInt(adminVolumeSlider.value);
             adminVolumeSlider.style.setProperty('--fill', pct + '%');
             if (adminVolumeValue) adminVolumeValue.textContent = pct + '%';
+            updateSliderDefaultState(adminVolumeSlider);
             queueOrRun((bridge) => {
                 if (bridge.admin_set_voice_volume) {
                     bridge.admin_set_voice_volume(pct / 100.0, () => {});


### PR DESCRIPTION
## Summary
- Add default value dot markers on admin panel sliders — dynamically positioned from config defaults
- Orange/green thumb + track color indicates altered vs default values
- Station rename now updates all historical scans in local DB and syncs to cloud API
- Remove audio pre-warm to prevent voice overlap on startup
- Tighten slider ranges for better UX

## Test plan
- [ ] Open admin panel, verify default dots align with slider thumbs on fresh DB
- [ ] Move a slider — thumb turns orange, move back to default — turns green
- [ ] Rename station — verify old scans update in local DB
- [ ] Verify no double audio on startup
- [ ] Test with different .env values — dots should reflect config

🤖 Generated with [Claude Code](https://claude.com/claude-code)