### PR TITLE
feat: camera device selector in admin panel

### DIFF
--- a/main.py
+++ b/main.py
@@ -405,6 +405,7 @@ class Api(QObject):
         self._config_defaults = {
             "dup_alert_ms": config.DUPLICATE_BADGE_ALERT_DURATION_MS,
             "voice_volume": config.VOICE_VOLUME,
+            "camera_device_id": config.CAMERA_DEVICE_ID,
             "greeting_cooldown": config.CAMERA_GREETING_COOLDOWN_SECONDS,
             "min_size_pct": config.CAMERA_MIN_SIZE_PCT,
             "absence_threshold": config.CAMERA_ABSENCE_THRESHOLD_SECONDS,
@@ -641,6 +642,76 @@ class Api(QObject):
         }
 
     @pyqtSlot(result="QVariant")
+    def enumerate_cameras(self) -> dict:
+        """Probe camera indices 0-10, return list of available cameras."""
+        cameras = []
+        try:
+            import cv2
+        except ImportError:
+            return {"ok": False, "cameras": [], "message": "OpenCV not available"}
+
+        active_id = config.CAMERA_DEVICE_ID
+        active_running = (self._proximity_manager
+                          and self._proximity_manager._running)
+
+        for i in range(11):
+            # Skip probing the active camera if it's running (exclusive access on Windows)
+            if i == active_id and active_running:
+                cameras.append({"index": i, "name": f"Camera {i} (active)"})
+                continue
+            cap = cv2.VideoCapture(i)
+            if cap.isOpened():
+                ret, _ = cap.read()
+                if ret:
+                    backend = cap.getBackendName() if hasattr(cap, 'getBackendName') else ""
+                    label = f"Camera {i}"
+                    if backend:
+                        label += f" ({backend})"
+                    cameras.append({"index": i, "name": label})
+                cap.release()
+
+        return {"ok": True, "cameras": cameras, "selected": active_id}
+
+    @pyqtSlot(int, result="QVariant")
+    def admin_select_camera(self, index: int) -> dict:
+        """Select camera by device index. Restarts camera if running. Persisted."""
+        index = max(0, min(10, index))
+        config.CAMERA_DEVICE_ID = index
+        self._save_setting("camera_device_id", str(index))
+
+        if self._proximity_manager:
+            was_running = self._proximity_manager._running
+            self._proximity_manager._camera_id = index
+            if was_running:
+                self._proximity_manager.stop()
+                # Delay restart to let old camera fully release
+                import threading
+                threading.Thread(
+                    target=self._deferred_camera_restart,
+                    daemon=True, name="camera-restart",
+                ).start()
+
+        LOGGER.info("[Admin] Camera selected: index %d", index)
+        return {"ok": True, "index": index}
+
+    def _deferred_camera_restart(self):
+        """Wait briefly, then restart camera on main thread."""
+        time.sleep(0.5)
+        from PyQt6.QtCore import QMetaObject, Qt
+        QMetaObject.invokeMethod(
+            self, "_do_camera_restart",
+            Qt.ConnectionType.QueuedConnection,
+        )
+
+    @pyqtSlot()
+    def _do_camera_restart(self):
+        """Restart camera on main thread after device change."""
+        if self._proximity_manager and not self._proximity_manager._running:
+            started = self._proximity_manager.start()
+            LOGGER.info("[Admin] Camera restart after device change: %s",
+                        "ok" if started else "failed")
+
+    @pyqtSlot(result="QVariant")
     def toggle_camera(self) -> dict:
         """Toggle camera detection on/off at runtime (1s debounce)."""
         if not self._proximity_manager:
@@ -860,6 +931,7 @@ class Api(QObject):
             "voice_enabled": self._voice_player.enabled if self._voice_player else False,
             "voice_volume": self._voice_player._volume if self._voice_player else 1.0,
             "camera_enabled": self._proximity_manager is not None,
+            "camera_device_id": config.CAMERA_DEVICE_ID,
             "camera_running": camera_running,
             "camera_overlay": camera_overlay,
             "greeting_cooldown": greeting_cooldown,
@@ -994,6 +1066,13 @@ class Api(QObject):
             except ValueError:
                 pass
         # Camera settings
+        v = db.get_meta("setting:camera_device_id")
+        if v is not None:
+            try:
+                config.CAMERA_DEVICE_ID = max(0, min(10, int(v)))
+                count += 1
+            except ValueError:
+                pass
         v = db.get_meta("setting:camera_overlay")
         if v is not None:
             config.CAMERA_SHOW_OVERLAY = v.lower() in ("true", "1")
@@ -1187,8 +1266,9 @@ class Api(QObject):
         """Reset all camera settings to .env defaults. Clears DB overrides."""
         db = self._service._db
         camera_keys = [
-            "camera_overlay", "greeting_cooldown", "min_size_pct",
-            "absence_threshold", "confirm_frames", "haar_min_neighbors",
+            "camera_device_id", "camera_overlay", "greeting_cooldown",
+            "min_size_pct", "absence_threshold", "confirm_frames",
+            "haar_min_neighbors",
         ]
         for key in camera_keys:
             db._connection.execute("DELETE FROM roster_meta WHERE key = ?", (f"setting:{key}",))
@@ -1202,9 +1282,11 @@ class Api(QObject):
         config.CAMERA_CONFIRM_FRAMES = d["confirm_frames"]
         config.CAMERA_HAAR_MIN_NEIGHBORS = d["haar_min_neighbors"]
         config.CAMERA_SHOW_OVERLAY = False  # production default
+        config.CAMERA_DEVICE_ID = d.get("camera_device_id", 0)
 
         # Push to live manager/detector
         if self._proximity_manager:
+            self._proximity_manager._camera_id = config.CAMERA_DEVICE_ID
             self._proximity_manager._cooldown = d["greeting_cooldown"]
             self._proximity_manager._min_size_pct = d["min_size_pct"]
             self._proximity_manager._absence_threshold = d["absence_threshold"]

--- a/web/index.html
+++ b/web/index.html
@@ -360,6 +360,17 @@
                 </div>
                 <div class="adm-section" id="admin-camera-section">
                     <div class="adm-section__header adm-section__header--camera"><i class="material-icons">videocam</i> Camera</div>
+                    <div class="adm-toggle-row" style="margin-bottom:8px;">
+                        <span class="adm-toggle-row__label">Device</span>
+                        <div style="display:flex;gap:6px;flex:1;align-items:center;">
+                            <select id="admin-camera-select" style="flex:1;padding:5px 8px;border:1px solid #ddd;border-radius:6px;font-size:0.82rem;background:#fff;color:#333;">
+                                <option value="-1">Click refresh to scan</option>
+                            </select>
+                            <button class="adm-btn adm-btn--secondary" id="admin-camera-refresh-btn" type="button" style="font-size:12px;padding:5px 8px;white-space:nowrap;" title="Scan for cameras">
+                                <i class="material-icons" style="font-size:16px;vertical-align:middle;">refresh</i>
+                            </button>
+                        </div>
+                    </div>
                     <div class="adm-toggle-row">
                         <span class="adm-toggle-row__label">Detection</span>
                         <button class="adm-toggle" id="admin-camera-detection-toggle" type="button"></button>

--- a/web/script.js
+++ b/web/script.js
@@ -1825,6 +1825,8 @@ ${destination}` : message;
     const adminVolumeSlider = document.getElementById('admin-volume-slider');
     const adminVolumeValue = document.getElementById('admin-volume-value');
     const adminCameraSection = document.getElementById('admin-camera-section');
+    const adminCameraSelect = document.getElementById('admin-camera-select');
+    const adminCameraRefreshBtn = document.getElementById('admin-camera-refresh-btn');
     const adminCameraDetectionToggle = document.getElementById('admin-camera-detection-toggle');
     const adminCameraOverlayToggle = document.getElementById('admin-camera-overlay-toggle');
     const adminCooldownSlider = document.getElementById('admin-cooldown-slider');
@@ -1974,6 +1976,8 @@ ${destination}` : message;
                         adminCameraSection.classList.toggle('adm-section--hidden', !result.camera_enabled);
                     }
                     if (result.camera_enabled) {
+                        // Populate camera device dropdown
+                        refreshCameraList(bridge, result.camera_device_id);
                         if (adminCameraDetectionToggle) {
                             adminCameraDetectionToggle.classList.toggle('active', !!result.camera_running);
                         }
@@ -2252,6 +2256,61 @@ ${destination}` : message;
             queueOrRun((bridge) => {
                 if (bridge.admin_set_camera_overlay) {
                     bridge.admin_set_camera_overlay(newState, () => {});
+                }
+            });
+        });
+    }
+
+    // Camera device selection
+    function refreshCameraList(bridge, selectedIndex) {
+        if (!bridge.enumerate_cameras || !adminCameraSelect) return;
+        adminCameraSelect.disabled = true;
+        adminCameraSelect.innerHTML = '<option value="-1">Scanning...</option>';
+        bridge.enumerate_cameras((result) => {
+            adminCameraSelect.innerHTML = '';
+            if (result && result.ok && result.cameras && result.cameras.length > 0) {
+                result.cameras.forEach((cam) => {
+                    const opt = document.createElement('option');
+                    opt.value = cam.index;
+                    opt.textContent = cam.name;
+                    if (cam.index === (selectedIndex !== undefined ? selectedIndex : result.selected)) {
+                        opt.selected = true;
+                    }
+                    adminCameraSelect.appendChild(opt);
+                });
+            } else {
+                adminCameraSelect.innerHTML = '<option value="-1">No cameras found</option>';
+            }
+            adminCameraSelect.disabled = false;
+        });
+    }
+
+    if (adminCameraRefreshBtn) {
+        adminCameraRefreshBtn.addEventListener('click', () => {
+            queueOrRun((bridge) => refreshCameraList(bridge));
+        });
+    }
+
+    if (adminCameraSelect) {
+        adminCameraSelect.addEventListener('change', () => {
+            const idx = parseInt(adminCameraSelect.value, 10);
+            if (idx < 0) return;
+            queueOrRun((bridge) => {
+                if (bridge.admin_select_camera) {
+                    bridge.admin_select_camera(idx, (result) => {
+                        if (result && result.ok) {
+                            // Camera may restart — update detection toggle after delay
+                            setTimeout(() => {
+                                if (bridge.get_camera_status) {
+                                    bridge.get_camera_status((s) => {
+                                        if (adminCameraDetectionToggle) {
+                                            adminCameraDetectionToggle.classList.toggle('active', !!s.running);
+                                        }
+                                    });
+                                }
+                            }, 1500);
+                        }
+                    });
                 }
             });
         });


### PR DESCRIPTION
## Summary
- Adds camera device dropdown to admin panel Camera section
- Enumerates available cameras (indices 0-10) with refresh button
- Selection persists to SQLite across restarts
- Auto-restarts detection when device changes while running
- Skips probing active camera to avoid Windows exclusive access issues
- Reset Camera to Defaults also resets device selection

## How it works
1. Admin opens Camera section -> sees "Device" dropdown
2. Clicks refresh icon -> app probes indices 0-10, shows available cameras
3. Selects a camera -> saved immediately, detection restarts if running
4. On next launch, saved device ID is restored before camera plugin loads

## Files changed
- `main.py` — `enumerate_cameras()`, `admin_select_camera()`, persistence in `load_saved_settings()`, reset integration
- `web/index.html` — Device select row with refresh button
- `web/script.js` — `refreshCameraList()` helper, change/click handlers, settings load

## Test plan
- [x] 361 unit tests passing
- [ ] Plug USB camera, click refresh, verify it appears in list
- [ ] Select external camera, verify detection restarts on it
- [ ] Restart app, verify saved camera selection persists
- [ ] Reset Camera to Defaults, verify device resets to env default

🤖 Generated with [Claude Code](https://claude.com/claude-code)